### PR TITLE
Fixed issue with byte string

### DIFF
--- a/two_factor/models.py
+++ b/two_factor/models.py
@@ -54,6 +54,9 @@ def key_validator(*args, **kwargs):
     """Wraps hex_validator generator, to keep makemigrations happy."""
     return hex_validator()(*args, **kwargs)
 
+def random_hex_str():
+    return random_hex().decode('utf-8')
+
 
 class PhoneDevice(Device):
     """
@@ -65,7 +68,7 @@ class PhoneDevice(Device):
     number = PhoneNumberField()
     key = models.CharField(max_length=40,
                            validators=[key_validator],
-                           default=random_hex,
+                           default=random_hex_str,
                            help_text="Hex-encoded secret key")
     method = models.CharField(max_length=4, choices=PHONE_METHODS,
                               verbose_name=_('method'))


### PR DESCRIPTION
When creating new Phone device from administrator panel, input is filled with b'.....'. Converted default value from bytes to string.

This is non-breaking bugfix.